### PR TITLE
Separate Ctrl-Up/Down from Ctrl-Left/Right

### DIFF
--- a/chrome/content/preferences.xul
+++ b/chrome/content/preferences.xul
@@ -62,6 +62,7 @@
       <preference id="closeLastWindowWithLastTab" name="extensions.tabutils.closeLastWindowWithLastTab" type="bool" inverted="true"/>
       <preference id="handleCtrlTab" name="extensions.tabutils.handleCtrlTab" type="bool" suggest="true"/>
       <preference id="handleCtrlArrow" name="extensions.tabutils.handleCtrlArrow" type="bool"/>
+      <preference id="handleCtrlArrowUpDown" name="extensions.tabutils.handleCtrlArrowUpDown" type="bool"/>
       <preference id="handleCtrl" name="extensions.tabutils.handleCtrl" type="bool"/>
 
       <preference id="openSearchInTab" name="browser.search.openintab" type="bool" suggest="true"/>
@@ -226,6 +227,7 @@
             <caption label="&handleCtrlTab.caption;"/>
             <checkbox preference="handleCtrlTab" label="&handleCtrlTab.label;"/>
             <checkbox preference="handleCtrlArrow" label="&handleCtrlArrow.label;"/>
+            <checkbox preference="handleCtrlArrowUpDown" label="&handleCtrlArrowUpDown.label;"/>
           </groupbox>
         </tabpanel>
       </tabpanels>

--- a/chrome/content/tabutils.js
+++ b/chrome/content/tabutils.js
@@ -898,6 +898,15 @@ tabutils._tabClosingOptions = function() {
     switch (event.keyCode) {
       case event.DOM_VK_UP:
       case event.DOM_VK_DOWN:
+        if (!TU_getPref("extensions.tabutils.handleCtrlArrowUpDown"))
+          return;
+        if (event.shiftKey)
+          return;
+        event.stopPropagation(); // Compat. with some sites
+        if (TU_getPref("extensions.tabutils.handleCtrl"))
+          gBrowser._previewMode = true;
+        break;
+
       case event.DOM_VK_LEFT:
       case event.DOM_VK_RIGHT:
         if (!TU_getPref("extensions.tabutils.handleCtrlArrow"))
@@ -939,7 +948,7 @@ tabutils._tabClosingOptions = function() {
         break;
       case event.DOM_VK_UP:
       case event.DOM_VK_DOWN:
-        if (!event.shiftKey && TU_getPref("extensions.tabutils.handleCtrlArrow")) {
+        if (!event.shiftKey && TU_getPref("extensions.tabutils.handleCtrlArrowUpDown")) {
           gBrowser.selectedTab = gBrowser.nextSiblingTabOf(gBrowser.selectedTab, event.keyCode == event.DOM_VK_UP ? -1 : 1, true);
           event.stopPropagation();
           event.preventDefault();
@@ -954,6 +963,12 @@ tabutils._tabClosingOptions = function() {
       case event.DOM_VK_RIGHT:
         if (event.ctrlKey && !event.altKey && !event.shiftKey && !event.metaKey &&
             TU_getPref("extensions.tabutils.handleCtrlArrow"))
+          event.stopPropagation(); // Compat. with some sites
+        break;
+      case event.DOM_VK_UP:
+      case event.DOM_VK_DOWN:
+        if (event.ctrlKey && !event.altKey && !event.shiftKey && !event.metaKey &&
+            TU_getPref("extensions.tabutils.handleCtrlArrowUpDown"))
           event.stopPropagation(); // Compat. with some sites
         break;
     }

--- a/chrome/locale/de/preferences.dtd
+++ b/chrome/locale/de/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Tab-Navigation mit Strg-Taste">
 <!ENTITY handleCtrlTab.label "Mit Strg+Tabulator in der Reihenfolge der letzten Benutzung durch Tabs navigieren">
 <!ENTITY handleCtrlArrow.label "Mit Strg+linke/rechte Pfeiltaste der Reihe nach durch Tabs navigieren">
+<!ENTITY handleCtrlArrowUpDown.label "Mit Strg+obere/untere Pfeiltaste der Reihe nach durch Tabs navigieren">
 <!ENTITY openNewWindow.caption "Verhalten beim Öffnen">
 <!ENTITY openNewWindow.label "Links, die ein neues Fenster erzwingen, öffnen in">
 <!ENTITY openExternal.label "Links aus externen Anwendungen öffnen in">

--- a/chrome/locale/en-US/preferences.dtd
+++ b/chrome/locale/en-US/preferences.dtd
@@ -62,7 +62,8 @@
 <!ENTITY maxTabsUndo.label "Max restorable tabs:">
 <!ENTITY handleCtrlTab.caption "Ctrl Tab">
 <!ENTITY handleCtrlTab.label "Ctrl+Tab to navigate tabs in most recently used order">
-<!ENTITY handleCtrlArrow.label "Ctrl+Arrow to navigate tabs in sequential order">
+<!ENTITY handleCtrlArrow.label "Ctrl+Arrow Left/Right to navigate tabs in sequential order">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl+Arrow Up/Down to navigate tabs in sequential order">
 <!ENTITY openNewWindow.caption "Open links in:">
 <!ENTITY openNewWindow.label "Open new-window links in:">
 <!ENTITY openExternal.label "Open links from external applications in:">

--- a/chrome/locale/es-ES/preferences.dtd
+++ b/chrome/locale/es-ES/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Tecla Ctrl">
 <!ENTITY handleCtrlTab.label "Ctrl+Tab recorre las pestañas en orden por uso más reciente">
 <!ENTITY handleCtrlArrow.label "Usar Ctrl+izquierda/derecha para recorrer las pestañas secuencialmente">
+<!ENTITY handleCtrlArrowUpDown.label "Usar Ctrl+arriba/abajo para recorrer las pestañas secuencialmente">
 <!ENTITY openNewWindow.caption "Apertura de enlaces">
 <!ENTITY openNewWindow.label "Abrir enlaces a una ventana nueva en:">
 <!ENTITY openExternal.label "Abrir enlaces de aplicaciones externas en:">

--- a/chrome/locale/it/preferences.dtd
+++ b/chrome/locale/it/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Utilizzo Ctrl e Tabulatore">
 <!ENTITY handleCtrlTab.label "Ctrl + Tab per navigare tra le schede nell'ordine di ultima visualizzazione">
 <!ENTITY handleCtrlArrow.label "Ctrl + Freccia sinistra/destra per navigare tra le schede">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl + Freccia alto/basso per navigare tra le schede">
 <!ENTITY openNewWindow.caption "Apri i Link in:">
 <!ENTITY openNewWindow.label "Apri in nuove finestre di Link in :">
 <!ENTITY openExternal.label "Apri i Link di altri programmi :">

--- a/chrome/locale/ja-JP/preferences.dtd
+++ b/chrome/locale/ja-JP/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Ctrl Tab">
 <!ENTITY handleCtrlTab.label "Ctrl+Tabで最近使った順にタブを移動する">
 <!ENTITY handleCtrlArrow.label "Ctrl+Left/Rightで順番にタブを移動する">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl+Up/Downで順番にタブを移動する">
 <!ENTITY openNewWindow.caption "リンクを開く動作:">
 <!ENTITY openNewWindow.label "新しいウィンドウに開くリンクを:">
 <!ENTITY openExternal.label "外部から読み込まれたリンクを:">

--- a/chrome/locale/pl/preferences.dtd
+++ b/chrome/locale/pl/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Skrót klawiszowy [Ctrl+Tab]">
 <!ENTITY handleCtrlTab.label "Skrót klawiszowy [Ctrl+Tab] przełącza w kolejności najczęściej oglądanych kart">
 <!ENTITY handleCtrlArrow.label "Skrót klawiszowy [Ctrl+lewa/prawa strzałka] przełącza w kolejności sekwencyjnej">
+<!ENTITY handleCtrlArrowUpDown.label "Skrót klawiszowy [Ctrl+góry/dole strzałka] przełącza w kolejności sekwencyjnej">
 <!ENTITY openNewWindow.caption "Otwieranie odnośników">
 <!ENTITY openNewWindow.label "Otwieraj odnośniki w">
 <!ENTITY openExternal.label "Otwieraj zewnętrzne odnośniki w">

--- a/chrome/locale/pt-BR/preferences.dtd
+++ b/chrome/locale/pt-BR/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Ctrl Tab">
 <!ENTITY handleCtrlTab.label "Ctrl+Tab para navegar as abas na ordem usada mais recentemente">
 <!ENTITY handleCtrlArrow.label "Ctrl+Seta da Esquerda/Direita para navegar pelas abas seqüencialmente">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl+Seta da Cima/Baixo para navegar pelas abas seqüencialmente">
 <!ENTITY openNewWindow.caption "Abrir ligação em:">
 <!ENTITY openNewWindow.label "Abrir ligações de novas janelas em:">
 <!ENTITY openExternal.label "Abrir ligações de aplicativos externos em:">

--- a/chrome/locale/ru/preferences.dtd
+++ b/chrome/locale/ru/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Ctrl-Tab">
 <!ENTITY handleCtrlTab.label "Ctrl-Tab переключает вкладки в порядке использования">
 <!ENTITY handleCtrlArrow.label "Ctrl-Left/Right переключают вкладки последовательно">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl-Up/Down переключают вкладки последовательно">
 <!ENTITY openNewWindow.caption "Открытие ссылок:">
 <!ENTITY openNewWindow.label "Открывать новые окна в:">
 <!ENTITY openExternal.label "Открывать ссылки из внешних приложений в:">

--- a/chrome/locale/zh-CN/preferences.dtd
+++ b/chrome/locale/zh-CN/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Ctrl Tab">
 <!ENTITY handleCtrlTab.label "Ctrl+Tab按最近访问的顺序切换标签页">
 <!ENTITY handleCtrlArrow.label "Ctrl+方向键按自然顺序切换标签页">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl+Arrow Up/Down to navigate tabs in sequential order">
 <!ENTITY openNewWindow.caption "链接打开位置">
 <!ENTITY openNewWindow.label "新窗口链接打开到:">
 <!ENTITY openExternal.label "外来链接打开到:">

--- a/chrome/locale/zh-TW/preferences.dtd
+++ b/chrome/locale/zh-TW/preferences.dtd
@@ -63,6 +63,7 @@
 <!ENTITY handleCtrlTab.caption "Ctrl+Tab">
 <!ENTITY handleCtrlTab.label "Ctrl+Tab 依最近瀏覽的順序切換">
 <!ENTITY handleCtrlArrow.label "Ctrl+←／→ 依分頁順序切換">
+<!ENTITY handleCtrlArrowUpDown.label "Ctrl+↑／↓ 依分頁順序切換">
 <!ENTITY openNewWindow.caption "開啟鏈結於:">
 <!ENTITY openNewWindow.label "開啟新視窗鏈結於:">
 <!ENTITY openExternal.label "開啟外部程式的鏈結於:">

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -24,6 +24,7 @@ pref("extensions.tabutils.removeUnintentionalBlank", false);
 pref("extensions.tabutils.closeLastWindowWithLastTab", false);
 pref("extensions.tabutils.handleCtrlTab", false);
 pref("extensions.tabutils.handleCtrlArrow", false);
+pref("extensions.tabutils.handleCtrlArrowUpDown", false);
 pref("extensions.tabutils.handleCtrl", true);
 
 pref("extensions.tabutils.singleWindowMode", false);


### PR DESCRIPTION
Separate Ctrl-Up/Down from Ctrl-Left/Right, so they can be enabled independently.

This patch introduces a new preference called extensions.tabutils.handleCtrlArrowUpDown which will be used for Ctrl-Up/Down exclusivly.

See also http://tabutils.uservoice.com/forums/43097-general/suggestions/2937986-add-possibility-to-change-the-crtl-arrow-shortcut for reference.
