### PR TITLE
Add tab-drop-indicator support for vertical tab orientation.

### DIFF
--- a/chrome/content/tabutils-vt.js
+++ b/chrome/content/tabutils-vt.js
@@ -25,6 +25,19 @@ tabutils._verticalTabs = function() {
   TU_hookCode("gBrowser.addTab", '!Services.prefs.getBoolPref("browser.tabs.animate")', 'this.mTabContainer.orient == "vertical" || $&');
   TU_hookCode("gBrowser.removeTab", '!Services.prefs.getBoolPref("browser.tabs.animate")', 'this.mTabContainer.orient == "vertical" || $&');
 
+  tabutils.addEventListener(gBrowser.mTabContainer, "dragover", function(event) {
+    var ind = this._tabDropIndicator.parentNode;
+    ind.style.position = "fixed";
+    ind.style.zIndex = 100;
+    var newIndex = this._getDropIndex(event);
+    var tab = this.childNodes[newIndex < this.childNodes.length ? newIndex : newIndex - 1];
+    var pos = tab.getBoundingClientRect().y;
+    if (newIndex == this.childNodes.length) {
+      pos += tab.getBoundingClientRect().height;
+    }
+    ind.style.top = pos + "px";
+  }, true);
+
   // Hide tabs toolbar in Full Screen mode
   TU_hookCode("FullScreen.mouseoverToggle", /(?=.*gNavToolbox.*)/, function() {
     if (document.getElementById("TabsToolbar").parentNode != gNavToolbox)

--- a/chrome/skin/tabutils_fx4.css
+++ b/chrome/skin/tabutils_fx4.css
@@ -25,8 +25,7 @@ window[v4="true"] browser {
 }
 
 .tabbrowser-arrowscrollbox[orient="vertical"] > .scrollbutton-up,
-.tabbrowser-arrowscrollbox[orient="vertical"] > .scrollbutton-down,
-.tabbrowser-tabs[orient="vertical"] > hbox > .tab-drop-indicator {
+.tabbrowser-arrowscrollbox[orient="vertical"] > .scrollbutton-down {
   display: none;
 }
 


### PR DESCRIPTION
When the tab bar is shown on the right or left, there is no tab drop indicator (showing where a tab will end up if you drag/drop it).  This pull request adds this indicator back for the vertical tab orientation.
